### PR TITLE
PrintScript 1.0 - Fixed NUMBER and STRING tokens regex's

### DIFF
--- a/lexer/src/main/kotlin/Lexer.kt
+++ b/lexer/src/main/kotlin/Lexer.kt
@@ -63,9 +63,3 @@ class Lexer(
         return Token(tokenType.token, position, trimmedVal)
     }
 }
-
-fun main() {
-    val lexer = Lexer("let a: number = 10;", 0, "utils/src/main/resources/tokenRegex.json")
-    val tokens = lexer.tokenize()
-    tokens.forEach { println(it) }
-}

--- a/lexer/src/test/resources/tokenRegex.json
+++ b/lexer/src/test/resources/tokenRegex.json
@@ -60,8 +60,8 @@
   "regex" : "[a-zA-Z_][a-zA-Z0-9_]*"
 }, {
   "token" : "NUMBER",
-  "regex" : "[0-9]+"
+  "regex" : "\\d+(\\.\\d+)?"
 }, {
   "token" : "STRING",
-  "regex" : "\"[^\"]*\""
+  "regex" : "\"[^\"]*\"|'[^']*'"
 } ]

--- a/utils/src/main/resources/tokenRegex.json
+++ b/utils/src/main/resources/tokenRegex.json
@@ -60,8 +60,8 @@
   "regex" : "[a-zA-Z_][a-zA-Z0-9_]*"
 }, {
   "token" : "NUMBER",
-  "regex" : "[0-9]+"
+  "regex" : "\\d+(\\.\\d+)?"
 }, {
   "token" : "STRING",
-  "regex" : "\"[^\"]*\""
+  "regex" : "\"[^\"]*\"|'[^']*'"
 } ]


### PR DESCRIPTION
- The String token regex was not supporting expressions with '
- The Number token regex was not supporting decimal expressions.